### PR TITLE
fix(deps): bump squizlabs/php_codesniffer to 3.13.6 (security advisory)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpunit/phpunit": "10.5.63",
         "phpstan/phpstan": "2.1.56",
-        "squizlabs/php_codesniffer": "3.13.5",
+        "squizlabs/php_codesniffer": "3.13.6",
         "jardisadapter/dbconnection": "^1.0",
         "jardissupport/dotenv": "^1.0"
     },


### PR DESCRIPTION
Automatisierter Update-Release. Zielversion: v1.0.2

squizlabs/php_codesniffer was pinned to 3.13.5 via exact-version constraint, which falls under security advisory PKSA-rdkp-vv9z-mjkg (OS Command Injection, affects < 3.13.6). Composer's default block-insecure policy refuses any fresh dependency resolution while this advisory is active, so CI dies in the "Install dependencies" step before a single check runs.

The exact-version pin itself predates this change; only the pinned version number moves forward.