### PR TITLE
release: v1.0.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpunit/phpunit": "10.5.63",
         "phpstan/phpstan": "2.1.56",
-        "squizlabs/php_codesniffer": "3.13.5",
+        "squizlabs/php_codesniffer": "3.13.6",
         "jardisadapter/dbconnection": "^1.0",
         "jardissupport/dotenv": "^1.0"
     },


### PR DESCRIPTION
Release v1.0.2

fix(deps): bump squizlabs/php_codesniffer to 3.13.6 (security advisory PKSA-rdkp-vv9z-mjkg).