### PR TITLE
feat(repository): add optional $expected conditions to update()/delete()

### DIFF
--- a/.claude/skills/support-repository/SKILL.md
+++ b/.claude/skills/support-repository/SKILL.md
@@ -49,9 +49,11 @@ $id = $repo->insert('users', 'id', ['id' => 42, ...], PkStrategy::NONE);        
 // UPDATE → bool
 $repo->update('users', 'id', 1, ['name' => 'Jane']);
 $repo->update('users', 'id', 1, []);  // no-op, returns true
+$repo->update('users', 'id', 1, ['name' => 'Jane'], ['name' => 'John']);  // conditional, see below
 
 // DELETE
 $repo->delete('users', 'id', 1);
+$repo->delete('users', 'id', 1, ['status' => 'archived']);  // conditional, see below
 $repo->deleteAll('users', 'id', [1, 2, 3]);  // IN-clause
 $repo->deleteAll('users', 'id', []);          // no-op
 
@@ -60,6 +62,18 @@ $row    = $repo->findById('users', 'id', 1);   // ?array
 $rows   = $repo->findByQuery($dbQueryBuilder);  // array<int, array>
 $exists = $repo->exists('users', 'id', 1);      // bool
 ```
+
+## CONDITIONAL WRITES (optimistic concurrency)
+```php
+update(string $table, string $pkColumn, int|string $id, array $values, array $expected = []): bool
+delete(string $table, string $pkColumn, int|string $id, array $expected = []): bool
+```
+- `$expected`: column => value the row must still carry (added as `AND`); `null` => `IS NULL`, not `= NULL`
+- `false` => row no longer matches `$expected` (or `id` doesn't exist) — 0 rows touched, nothing written
+- Values must be `scalar|null` — object/array => `InvalidArgumentException`
+- Empty `$values` + non-empty `$expected` => `InvalidArgumentException` (the empty-`$values` no-op shortcut would otherwise skip the check silently)
+- Use for optimistic locking / read-then-write races: caller re-supplies the values it read, repository guarantees they still held at write time
+- Shared logic: `Handler/Query/ApplyExpectedConditions` (invokable, applies `$expected` to `DbUpdate`/`DbDelete`)
 
 ## READ/WRITE SPLITTING
 - `insert`, `update`, `delete`, `deleteAll` → `$pool->getWriter()`
@@ -93,6 +107,7 @@ use JardisSupport\Contract\Repository\Exception\{PersistException, RecordNotFoun
 |---------|-----------|
 | Insert: empty `$values`, `NONE` without PK, `NONE` wrong PK type, `INTEGER` 3 retries exhausted | `PersistException` |
 | Update/Delete/DeleteAll: `PDOException` | `PersistException` |
+| `$expected` non-scalar value, or empty `$values` with non-empty `$expected` | `InvalidArgumentException` |
 | Duplicate Key detection | MySQL/Postgres SQLSTATE `23000`; SQLite string match `UNIQUE constraint failed` |
 | `RecordNotFoundException` | Defined in contract — not thrown internally; for custom implementations |
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ An implementation of the repository pattern for PHP: a generic CRUD repository o
 - **Query Builder Support** — `findByQuery()` accepts any `DbQueryBuilderInterface` for complex SELECT statements
 - **Exists Check** — `exists()` avoids full row fetches when only presence matters
 - **Batch Delete** — `deleteAll()` removes multiple rows in a single call
+- **Conditional Writes** — optional `$expected` on `update()`/`delete()` guards against stale reads (optimistic concurrency); returns `false` when the row no longer matches
 - **Lazy Connection Initialization** — reader and writer connections are opened only when first used
 
 ---
@@ -91,6 +92,39 @@ if ($repository->exists('users', 'id', $userId)) {
     // ...
 }
 ```
+
+### Conditional writes (optimistic concurrency)
+
+```php
+public function update(
+    string $table, string $pkColumn, int|string $id, array $values,
+    array $expected = [],   // column => value the row must still carry; null => IS NULL
+): bool;
+
+public function delete(
+    string $table, string $pkColumn, int|string $id,
+    array $expected = [],
+): bool;
+```
+
+`$expected` pins the write to the values a caller already read — one extra `AND` condition per column. If the row no longer carries those values, the statement touches 0 rows and the call returns `false` instead of silently overwriting a stale read.
+
+```php
+// Two readers fetch the same row: ['status' => 'pending', ...]
+$row = $repository->findById('orders', 'id', $id);
+
+// Reader A writes first — the row still matches, write succeeds
+$repository->update('orders', 'id', $id, ['status' => 'confirmed'], ['status' => 'pending']); // true
+
+// Reader B writes second, unaware A already won — the row no longer matches
+$repository->update('orders', 'id', $id, ['status' => 'cancelled'], ['status' => 'pending']); // false
+```
+
+> - `null` in `$expected` maps to `IS NULL`, not `= NULL`.
+> - `false` means the row no longer carries the expected values — or the `id` doesn't exist. For a conflict check both are the same signal: the read this write was based on is no longer valid.
+> - `$expected` values must be `scalar|null`; an object or array throws `InvalidArgumentException`.
+> - An empty `$values` combined with a non-empty `$expected` throws `InvalidArgumentException` too — the existing "nothing to write" shortcut would otherwise skip the check silently and return `true` unchecked. Use `exists()`/`findById()` for a pure read-side check.
+> - **MySQL note:** `rowCount()` counts changed rows — an update that would set identical values reports `0`. This doesn't fire for repositories built from changed-field diffs, but it's a caveat if `$values` is assembled differently.
 
 ## Documentation
 

--- a/src/Handler/DeleteHandler.php
+++ b/src/Handler/DeleteHandler.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace JardisSupport\Repository\Handler;
 
+use Closure;
 use JardisSupport\Contract\DbQuery\DbPreparedQueryInterface;
 use JardisSupport\Contract\Repository\Exception\PersistException;
 use JardisSupport\DbQuery\DbDelete;
+use JardisSupport\Repository\Handler\Query\ApplyExpectedConditions;
 use PDOException;
 
 /**
@@ -14,25 +16,32 @@ use PDOException;
  */
 final class DeleteHandler
 {
+    private readonly Closure $applyExpectedConditions;
+
     public function __construct(
         private readonly QueryExecutor $executor,
     ) {
+        $this->applyExpectedConditions = (new ApplyExpectedConditions())->__invoke(...);
     }
 
     /**
      * @param string $table Tabellenname
      * @param string $pkColumn Primary-Key-Spalte
      * @param int|string $id Primary-Key-Wert
+     * @param array<string, scalar|null> $expected Spalte => erwarteter Wert; null => IS NULL
      */
     public function __invoke(
         string $table,
         string $pkColumn,
         int|string $id,
+        array $expected = [],
     ): bool {
-        $prepared = (new DbDelete())
+        $query = (new DbDelete())
             ->from($table)
-            ->where($pkColumn)->equals($id)
-            ->sql($this->executor->getDialect(), prepared: true);
+            ->where($pkColumn)->equals($id);
+        $query = ($this->applyExpectedConditions)($query, $expected);
+
+        $prepared = $query->sql($this->executor->getDialect(), prepared: true);
         \assert($prepared instanceof DbPreparedQueryInterface);
 
         try {

--- a/src/Handler/Query/ApplyExpectedConditions.php
+++ b/src/Handler/Query/ApplyExpectedConditions.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JardisSupport\Repository\Handler\Query;
+
+use JardisSupport\Contract\DbQuery\DbDeleteBuilderInterface;
+use JardisSupport\Contract\DbQuery\DbQueryBuilderInterface;
+use JardisSupport\Contract\DbQuery\DbUpdateBuilderInterface;
+
+/**
+ * Applies expected-value conditions (optimistic-concurrency guard) to an UPDATE/DELETE query.
+ *
+ * Each entry becomes an additional AND-condition: `null` maps to IS NULL, every other
+ * scalar maps to an equality check. Shared by UpdateHandler and DeleteHandler.
+ */
+final class ApplyExpectedConditions
+{
+    /**
+     * @param array<string, scalar|null> $expected Spalte => erwarteter Wert; null => IS NULL
+     */
+    public function __invoke(
+        DbQueryBuilderInterface|DbUpdateBuilderInterface|DbDeleteBuilderInterface $query,
+        array $expected,
+    ): DbQueryBuilderInterface|DbUpdateBuilderInterface|DbDeleteBuilderInterface {
+        foreach ($expected as $column => $value) {
+            $this->assertScalarOrNull($column, $value);
+
+            $query = $value === null
+                ? $query->and($column)->isNull()
+                : $query->and($column)->equals($value);
+        }
+
+        return $query;
+    }
+
+    private function assertScalarOrNull(string $column, mixed $value): void
+    {
+        if ($value !== null && !is_scalar($value)) {
+            throw new \InvalidArgumentException(
+                'Expected condition value for "' . $column . '" must be scalar or null, '
+                    . get_debug_type($value) . ' given.'
+            );
+        }
+    }
+}

--- a/src/Handler/UpdateHandler.php
+++ b/src/Handler/UpdateHandler.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace JardisSupport\Repository\Handler;
 
+use Closure;
 use JardisSupport\Contract\DbQuery\DbPreparedQueryInterface;
 use JardisSupport\Contract\Repository\Exception\PersistException;
 use JardisSupport\DbQuery\DbUpdate;
+use JardisSupport\Repository\Handler\Query\ApplyExpectedConditions;
 use PDOException;
 
 /**
@@ -14,9 +16,12 @@ use PDOException;
  */
 final class UpdateHandler
 {
+    private readonly Closure $applyExpectedConditions;
+
     public function __construct(
         private readonly QueryExecutor $executor,
     ) {
+        $this->applyExpectedConditions = (new ApplyExpectedConditions())->__invoke(...);
     }
 
     /**
@@ -24,22 +29,32 @@ final class UpdateHandler
      * @param string $pkColumn Primary-Key-Spalte
      * @param int|string $id Primary-Key-Wert
      * @param array<string, mixed> $values Geaenderte Spaltenwerte
+     * @param array<string, scalar|null> $expected Spalte => erwarteter Wert; null => IS NULL
      */
     public function __invoke(
         string $table,
         string $pkColumn,
         int|string $id,
         array $values,
+        array $expected = [],
     ): bool {
         if (empty($values)) {
+            if ($expected !== []) {
+                throw new \InvalidArgumentException(
+                    'Cannot verify $expected without $values in update() for ' . $table
+                );
+            }
+
             return true;
         }
 
-        $prepared = (new DbUpdate())
+        $query = (new DbUpdate())
             ->table($table)
             ->setMultiple($values)
-            ->where($pkColumn)->equals($id)
-            ->sql($this->executor->getDialect(), prepared: true);
+            ->where($pkColumn)->equals($id);
+        $query = ($this->applyExpectedConditions)($query, $expected);
+
+        $prepared = $query->sql($this->executor->getDialect(), prepared: true);
         \assert($prepared instanceof DbPreparedQueryInterface);
 
         try {

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -55,25 +55,34 @@ final class Repository implements RepositoryInterface
         return ($this->insertHandler)($table, $pkColumn, $values, $pkStrategy);
     }
 
+    /**
+     * @param array<string, mixed> $values
+     * @param array<string, scalar|null> $expected Spalte => erwarteter Wert; null => IS NULL
+     */
     public function update(
         string $table,
         string $pkColumn,
         int|string $id,
         array $values,
+        array $expected = [],
     ): bool {
         $this->updateHandler ??= new UpdateHandler($this->writer());
 
-        return ($this->updateHandler)($table, $pkColumn, $id, $values);
+        return ($this->updateHandler)($table, $pkColumn, $id, $values, $expected);
     }
 
+    /**
+     * @param array<string, scalar|null> $expected Spalte => erwarteter Wert; null => IS NULL
+     */
     public function delete(
         string $table,
         string $pkColumn,
         int|string $id,
+        array $expected = [],
     ): bool {
         $this->deleteHandler ??= new DeleteHandler($this->writer());
 
-        return ($this->deleteHandler)($table, $pkColumn, $id);
+        return ($this->deleteHandler)($table, $pkColumn, $id, $expected);
     }
 
     public function deleteAll(

--- a/tests/Integration/RepositoryPostgresTest.php
+++ b/tests/Integration/RepositoryPostgresTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JardisSupport\Repository\Tests\Integration;
+
+use JardisAdapter\DbConnection\ConnectionPool;
+use JardisAdapter\DbConnection\Factory\ConnectionFactory;
+use JardisSupport\Contract\DbConnection\ConnectionPoolInterface;
+use JardisSupport\Repository\Repository;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * I2: Optimistic-concurrency collision scenario against PostgreSQL — same scenario as
+ * RepositoryTest::testConditionalUpdateCollisionScenario() (I1, MySQL), proving the
+ * dialect divergence does not break the $expected-conditions contract.
+ */
+final class RepositoryPostgresTest extends TestCase
+{
+    private const TABLE = 'test_conditional_write';
+    private const PK = 'id';
+
+    private static ConnectionPoolInterface $pool;
+    private static PDO $pdo;
+
+    public static function setUpBeforeClass(): void
+    {
+        $factory = new ConnectionFactory();
+        $writer = $factory->postgres(
+            host: $_ENV['POSTGRES_HOST'] ?? 'postgres',
+            user: $_ENV['POSTGRES_USER'] ?? 'test_user',
+            password: $_ENV['POSTGRES_PASSWORD'] ?? 'test_password',
+            database: $_ENV['POSTGRES_DATABASE'] ?? 'test_db',
+            port: (int) ($_ENV['POSTGRES_PORT'] ?? 5432),
+        );
+
+        self::$pool = new ConnectionPool(
+            writer: $writer,
+            readers: [],
+        );
+
+        self::$pdo = self::$pool->getWriter()->pdo();
+
+        self::$pdo->exec('DROP TABLE IF EXISTS ' . self::TABLE);
+        self::$pdo->exec('
+            CREATE TABLE ' . self::TABLE . ' (
+                id SERIAL PRIMARY KEY,
+                name VARCHAR(255) NOT NULL,
+                age INT
+            )
+        ');
+    }
+
+    protected function setUp(): void
+    {
+        self::$pdo->exec('TRUNCATE TABLE ' . self::TABLE . ' RESTART IDENTITY');
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        self::$pdo->exec('DROP TABLE IF EXISTS ' . self::TABLE);
+    }
+
+    public function testConditionalUpdateCollisionScenario(): void
+    {
+        $repositoryA = new Repository(self::$pool);
+        $repositoryB = new Repository(self::$pool);
+
+        $id = $repositoryA->insert(self::TABLE, self::PK, ['name' => 'Alice', 'age' => 100]);
+
+        // Both "clients" read the same starting age (100). PDO_PGSQL may return numeric
+        // columns as strings depending on driver/version, so compare numerically.
+        $readByA = $repositoryA->findById(self::TABLE, self::PK, $id);
+        $readByB = $repositoryB->findById(self::TABLE, self::PK, $id);
+        $this->assertSame(100, (int) $readByA['age']);
+        $this->assertSame(100, (int) $readByB['age']);
+
+        // A writes first, expecting the age it read.
+        $resultA = $repositoryA->update(self::TABLE, self::PK, $id, ['age' => 150], ['age' => 100]);
+        $this->assertTrue($resultA);
+
+        // B writes with the now-stale expectation and loses.
+        $resultB = $repositoryB->update(self::TABLE, self::PK, $id, ['age' => 200], ['age' => 100]);
+        $this->assertFalse($resultB);
+
+        $row = $repositoryA->findById(self::TABLE, self::PK, $id);
+        $this->assertSame(150, (int) $row['age']);
+    }
+}

--- a/tests/Integration/RepositoryTest.php
+++ b/tests/Integration/RepositoryTest.php
@@ -490,4 +490,31 @@ final class RepositoryTest extends TestCase
 
         $this->assertFalse($this->repository->exists(self::TABLE_AUTO, self::PK, $id));
     }
+
+    // ── CONDITIONAL WRITE — COLLISION SCENARIO (I1, MySQL) ────────────
+
+    public function testConditionalUpdateCollisionScenario(): void
+    {
+        $repositoryA = new Repository(self::$pool);
+        $repositoryB = new Repository(self::$pool);
+
+        $id = $repositoryA->insert(self::TABLE_AUTO, self::PK, ['name' => 'Alice', 'age' => 100]);
+
+        // Both "clients" read the same starting age (100).
+        $readByA = $repositoryA->findById(self::TABLE_AUTO, self::PK, $id);
+        $readByB = $repositoryB->findById(self::TABLE_AUTO, self::PK, $id);
+        $this->assertSame(100, $readByA['age']);
+        $this->assertSame(100, $readByB['age']);
+
+        // A writes first, expecting the age it read.
+        $resultA = $repositoryA->update(self::TABLE_AUTO, self::PK, $id, ['age' => 150], ['age' => 100]);
+        $this->assertTrue($resultA);
+
+        // B writes with the now-stale expectation and loses.
+        $resultB = $repositoryB->update(self::TABLE_AUTO, self::PK, $id, ['age' => 200], ['age' => 100]);
+        $this->assertFalse($resultB);
+
+        $row = $repositoryA->findById(self::TABLE_AUTO, self::PK, $id);
+        $this->assertSame(150, $row['age']);
+    }
 }

--- a/tests/Unit/Handler/Query/ApplyExpectedConditionsTest.php
+++ b/tests/Unit/Handler/Query/ApplyExpectedConditionsTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JardisSupport\Repository\Tests\Unit\Handler\Query;
+
+use JardisSupport\DbQuery\DbUpdate;
+use JardisSupport\Repository\Handler\Query\ApplyExpectedConditions;
+use PHPUnit\Framework\TestCase;
+
+final class ApplyExpectedConditionsTest extends TestCase
+{
+    private ApplyExpectedConditions $applyExpectedConditions;
+
+    protected function setUp(): void
+    {
+        $this->applyExpectedConditions = new ApplyExpectedConditions();
+    }
+
+    // ── U1: leeres $expected beruehrt die Query-Baukette strukturell nicht ──
+
+    public function testEmptyExpectedReturnsSameQueryInstance(): void
+    {
+        $query = (new DbUpdate())->table('items')->setMultiple(['name' => 'X'])->where('id')->equals(1);
+
+        $result = ($this->applyExpectedConditions)($query, []);
+
+        $this->assertSame($query, $result);
+    }
+
+    public function testEmptyExpectedProducesByteIdenticalSql(): void
+    {
+        $baseline = (new DbUpdate())
+            ->table('items')->setMultiple(['name' => 'X'])->where('id')->equals(1)
+            ->sql('sqlite', prepared: true);
+
+        $query = (new DbUpdate())->table('items')->setMultiple(['name' => 'X'])->where('id')->equals(1);
+        $withEmptyExpected = ($this->applyExpectedConditions)($query, [])
+            ->sql('sqlite', prepared: true);
+
+        $this->assertSame($baseline->sql(), $withEmptyExpected->sql());
+        $this->assertSame($baseline->bindings(), $withEmptyExpected->bindings());
+    }
+
+    // ── Bedingungskette ──
+
+    public function testScalarValueAppendsEqualsCondition(): void
+    {
+        $query = (new DbUpdate())->table('items')->setMultiple(['name' => 'X'])->where('id')->equals(1);
+
+        $prepared = ($this->applyExpectedConditions)($query, ['status' => 'active'])
+            ->sql('sqlite', prepared: true);
+
+        $this->assertStringContainsString('AND status = ?', $prepared->sql());
+        $this->assertSame(['X', 1, 'active'], $prepared->bindings());
+    }
+
+    public function testNullValueAppendsIsNullCondition(): void
+    {
+        $query = (new DbUpdate())->table('items')->setMultiple(['name' => 'X'])->where('id')->equals(1);
+
+        $prepared = ($this->applyExpectedConditions)($query, ['email' => null])
+            ->sql('sqlite', prepared: true);
+
+        $this->assertStringContainsString('AND email IS NULL', $prepared->sql());
+        $this->assertSame(['X', 1], $prepared->bindings());
+    }
+
+    // ── U5: Mehrfeld-Erwartung ──
+
+    public function testMultipleExpectedConditionsAreAllChained(): void
+    {
+        $query = (new DbUpdate())->table('items')->setMultiple(['name' => 'X'])->where('id')->equals(1);
+
+        $prepared = ($this->applyExpectedConditions)($query, ['status' => 'active', 'email' => null])
+            ->sql('sqlite', prepared: true);
+
+        $this->assertStringContainsString('AND status = ?', $prepared->sql());
+        $this->assertStringContainsString('AND email IS NULL', $prepared->sql());
+        $this->assertSame(['X', 1, 'active'], $prepared->bindings());
+    }
+
+    // ── U10: Vertragsgrenze — nur scalar|null ──
+
+    public function testNonScalarObjectValueThrowsInvalidArgumentException(): void
+    {
+        $query = (new DbUpdate())->table('items')->setMultiple(['name' => 'X'])->where('id')->equals(1);
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        ($this->applyExpectedConditions)($query, ['createdAt' => new \DateTime()]);
+    }
+
+    public function testArrayValueThrowsInvalidArgumentException(): void
+    {
+        $query = (new DbUpdate())->table('items')->setMultiple(['name' => 'X'])->where('id')->equals(1);
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        ($this->applyExpectedConditions)($query, ['tags' => ['a', 'b']]);
+    }
+}

--- a/tests/Unit/PdoRepositoryTest.php
+++ b/tests/Unit/PdoRepositoryTest.php
@@ -31,7 +31,8 @@ final class PdoRepositoryTest extends TestCase
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 name TEXT NOT NULL,
                 email TEXT,
-                status TEXT DEFAULT \'active\'
+                status TEXT DEFAULT \'active\',
+                active INTEGER
             )
         ');
 
@@ -219,5 +220,311 @@ final class PdoRepositoryTest extends TestCase
         $query = (new DbQuery())->select('COUNT(*) as cnt')->from(self::TABLE);
         $rows = $this->repository->findByQuery($query);
         $this->assertSame(1, (int) $rows[0]['cnt']);
+    }
+
+    // ── CONDITIONAL UPDATE (expected) ──────────────────────────────
+
+    public function testUpdateWithMatchingExpectedReturnsTrueAndUpdatesRow(): void
+    {
+        $id = $this->repository->insert(self::TABLE, self::PK, ['name' => 'Alice', 'status' => 'active']);
+
+        $result = $this->repository->update(
+            self::TABLE,
+            self::PK,
+            $id,
+            ['name' => 'Alice Updated'],
+            ['status' => 'active'],
+        );
+
+        $this->assertTrue($result);
+        $row = $this->repository->findById(self::TABLE, self::PK, $id);
+        $this->assertSame('Alice Updated', $row['name']);
+    }
+
+    public function testUpdateWithStaleExpectedReturnsFalseAndLeavesRowUnchanged(): void
+    {
+        $id = $this->repository->insert(self::TABLE, self::PK, ['name' => 'Alice', 'status' => 'active']);
+
+        $result = $this->repository->update(
+            self::TABLE,
+            self::PK,
+            $id,
+            ['name' => 'Alice Updated'],
+            ['status' => 'stale-value'],
+        );
+
+        $this->assertFalse($result);
+        $row = $this->repository->findById(self::TABLE, self::PK, $id);
+        $this->assertSame('Alice', $row['name']);
+    }
+
+    // U4: null-Erwartung in beide Richtungen
+    public function testUpdateWithNullExpectedMatchesNullColumn(): void
+    {
+        $id = $this->repository->insert(self::TABLE, self::PK, ['name' => 'Alice']);
+
+        $result = $this->repository->update(
+            self::TABLE,
+            self::PK,
+            $id,
+            ['name' => 'Alice Updated'],
+            ['email' => null],
+        );
+
+        $this->assertTrue($result);
+    }
+
+    public function testUpdateWithNullExpectedDoesNotMatchNonNullColumn(): void
+    {
+        $id = $this->repository->insert(self::TABLE, self::PK, ['name' => 'Alice', 'email' => 'alice@example.com']);
+
+        $result = $this->repository->update(
+            self::TABLE,
+            self::PK,
+            $id,
+            ['name' => 'Alice Updated'],
+            ['email' => null],
+        );
+
+        $this->assertFalse($result);
+    }
+
+    // U5: Mehrfeld-Erwartung
+    public function testUpdateWithMultiFieldExpectedMatchesAllColumns(): void
+    {
+        $id = $this->repository->insert(
+            self::TABLE,
+            self::PK,
+            ['name' => 'Alice', 'email' => 'alice@example.com', 'status' => 'active'],
+        );
+
+        $result = $this->repository->update(
+            self::TABLE,
+            self::PK,
+            $id,
+            ['name' => 'Alice Updated'],
+            ['email' => 'alice@example.com', 'status' => 'active'],
+        );
+
+        $this->assertTrue($result);
+    }
+
+    public function testUpdateWithMultiFieldExpectedFailsWhenOneFieldMismatches(): void
+    {
+        $id = $this->repository->insert(
+            self::TABLE,
+            self::PK,
+            ['name' => 'Alice', 'email' => 'alice@example.com', 'status' => 'active'],
+        );
+
+        $result = $this->repository->update(
+            self::TABLE,
+            self::PK,
+            $id,
+            ['name' => 'Alice Updated'],
+            ['email' => 'alice@example.com', 'status' => 'inactive'],
+        );
+
+        $this->assertFalse($result);
+        $row = $this->repository->findById(self::TABLE, self::PK, $id);
+        $this->assertSame('Alice', $row['name']);
+    }
+
+    // ── CONDITIONAL DELETE (expected) ──────────────────────────────
+
+    public function testDeleteWithMatchingExpectedReturnsTrueAndRemovesRow(): void
+    {
+        $id = $this->repository->insert(self::TABLE, self::PK, ['name' => 'Alice', 'status' => 'active']);
+
+        $result = $this->repository->delete(self::TABLE, self::PK, $id, ['status' => 'active']);
+
+        $this->assertTrue($result);
+        $this->assertNull($this->repository->findById(self::TABLE, self::PK, $id));
+    }
+
+    public function testDeleteWithStaleExpectedReturnsFalseAndLeavesRowInPlace(): void
+    {
+        $id = $this->repository->insert(self::TABLE, self::PK, ['name' => 'Alice', 'status' => 'active']);
+
+        $result = $this->repository->delete(self::TABLE, self::PK, $id, ['status' => 'stale-value']);
+
+        $this->assertFalse($result);
+        $this->assertNotNull($this->repository->findById(self::TABLE, self::PK, $id));
+    }
+
+    public function testDeleteWithNullExpectedMatchesNullColumn(): void
+    {
+        $id = $this->repository->insert(self::TABLE, self::PK, ['name' => 'Alice']);
+
+        $result = $this->repository->delete(self::TABLE, self::PK, $id, ['email' => null]);
+
+        $this->assertTrue($result);
+        $this->assertNull($this->repository->findById(self::TABLE, self::PK, $id));
+    }
+
+    // ── VERTRAGSGRENZEN (Blocker-Befunde) ──────────────────────────
+
+    // U9: leeres $values + gesetztes $expected
+    public function testUpdateWithEmptyValuesAndNonEmptyExpectedThrows(): void
+    {
+        $id = $this->repository->insert(self::TABLE, self::PK, ['name' => 'Alice', 'status' => 'active']);
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->repository->update(self::TABLE, self::PK, $id, [], ['status' => 'active']);
+    }
+
+    public function testUpdateWithEmptyValuesAndEmptyExpectedStillReturnsTrue(): void
+    {
+        $id = $this->repository->insert(self::TABLE, self::PK, ['name' => 'Alice']);
+
+        $result = $this->repository->update(self::TABLE, self::PK, $id, [], []);
+
+        $this->assertTrue($result);
+    }
+
+    // U10: nur scalar|null in $expected
+    public function testUpdateWithObjectExpectedValueThrows(): void
+    {
+        $id = $this->repository->insert(self::TABLE, self::PK, ['name' => 'Alice']);
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->repository->update(self::TABLE, self::PK, $id, ['name' => 'Bob'], ['status' => new \DateTime()]);
+    }
+
+    public function testUpdateWithArrayExpectedValueThrows(): void
+    {
+        $id = $this->repository->insert(self::TABLE, self::PK, ['name' => 'Alice']);
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->repository->update(self::TABLE, self::PK, $id, ['name' => 'Bob'], ['status' => ['active']]);
+    }
+
+    public function testDeleteWithObjectExpectedValueThrows(): void
+    {
+        $id = $this->repository->insert(self::TABLE, self::PK, ['name' => 'Alice']);
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->repository->delete(self::TABLE, self::PK, $id, ['status' => new \DateTime()]);
+    }
+
+    // U11: leerer String vs. NULL sind verschiedene Erwartungen
+    public function testUpdateWithEmptyStringExpectedDoesNotMatchNullColumn(): void
+    {
+        $id = $this->repository->insert(self::TABLE, self::PK, ['name' => 'Alice', 'email' => null]);
+
+        $result = $this->repository->update(
+            self::TABLE,
+            self::PK,
+            $id,
+            ['name' => 'Alice Updated'],
+            ['email' => ''],
+        );
+
+        $this->assertFalse($result);
+    }
+
+    public function testUpdateWithNullExpectedDoesNotMatchEmptyStringColumn(): void
+    {
+        $id = $this->repository->insert(self::TABLE, self::PK, ['name' => 'Alice', 'email' => '']);
+
+        $result = $this->repository->update(
+            self::TABLE,
+            self::PK,
+            $id,
+            ['name' => 'Alice Updated'],
+            ['email' => null],
+        );
+
+        $this->assertFalse($result);
+    }
+
+    public function testUpdateWithEmptyStringExpectedMatchesEmptyStringColumn(): void
+    {
+        $id = $this->repository->insert(self::TABLE, self::PK, ['name' => 'Alice', 'email' => '']);
+
+        $result = $this->repository->update(
+            self::TABLE,
+            self::PK,
+            $id,
+            ['name' => 'Alice Updated'],
+            ['email' => ''],
+        );
+
+        $this->assertTrue($result);
+    }
+
+    // U12: Treiber-Verhalten gepinnt (SQLite), nicht versprochen
+    public function testUpdateWithStringNumericExpectedMatchesIntegerColumn(): void
+    {
+        $id = $this->repository->insert(self::TABLE, self::PK, ['name' => 'Alice']);
+
+        $result = $this->repository->update(
+            self::TABLE,
+            self::PK,
+            $id,
+            ['name' => 'Alice Updated'],
+            ['id' => (string) $id],
+        );
+
+        $this->assertTrue($result);
+    }
+
+    public function testUpdateWithBooleanExpectedMatchesBooleanColumnParityWithValues(): void
+    {
+        $id = $this->repository->insert(self::TABLE, self::PK, ['name' => 'Alice', 'active' => true]);
+
+        $result = $this->repository->update(
+            self::TABLE,
+            self::PK,
+            $id,
+            ['name' => 'Alice Updated'],
+            ['active' => true],
+        );
+
+        $this->assertTrue($result);
+    }
+
+    public function testUpdateWithBooleanExpectedDoesNotMatchOppositeBooleanColumn(): void
+    {
+        $id = $this->repository->insert(self::TABLE, self::PK, ['name' => 'Alice', 'active' => true]);
+
+        $result = $this->repository->update(
+            self::TABLE,
+            self::PK,
+            $id,
+            ['name' => 'Alice Updated'],
+            ['active' => false],
+        );
+
+        $this->assertFalse($result);
+    }
+
+    // U13: Erwartung auf nicht existierende Spalte -> PersistException
+    public function testUpdateWithExpectedOnNonexistentColumnThrowsPersistException(): void
+    {
+        $id = $this->repository->insert(self::TABLE, self::PK, ['name' => 'Alice']);
+
+        $this->expectException(PersistException::class);
+
+        $this->repository->update(
+            self::TABLE,
+            self::PK,
+            $id,
+            ['name' => 'Alice Updated'],
+            ['nonexistent_column' => 'value'],
+        );
+    }
+
+    public function testDeleteWithExpectedOnNonexistentColumnThrowsPersistException(): void
+    {
+        $id = $this->repository->insert(self::TABLE, self::PK, ['name' => 'Alice']);
+
+        $this->expectException(PersistException::class);
+
+        $this->repository->delete(self::TABLE, self::PK, $id, ['nonexistent_column' => 'value']);
     }
 }

--- a/tests/Unit/RepositoryConditionalWriteSqliteCollisionTest.php
+++ b/tests/Unit/RepositoryConditionalWriteSqliteCollisionTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JardisSupport\Repository\Tests\Unit;
+
+use JardisAdapter\DbConnection\ConnectionPool;
+use JardisAdapter\DbConnection\Factory\ConnectionFactory;
+use JardisSupport\Contract\DbConnection\ConnectionPoolInterface;
+use JardisSupport\Repository\Repository;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * I3: Optimistic-concurrency collision scenario against SQLite via the adapter path
+ * (ConnectionFactory/ConnectionPool) — same layer and scenario as
+ * RepositoryTest::testConditionalUpdateCollisionScenario() (I1, MySQL) and
+ * RepositoryPostgresTest::testConditionalUpdateCollisionScenario() (I2, PostgreSQL).
+ * SQLite needs no Docker service, so this runs as a Unit test.
+ */
+final class RepositoryConditionalWriteSqliteCollisionTest extends TestCase
+{
+    private const TABLE = 'accounts';
+    private const PK = 'id';
+
+    private ConnectionPoolInterface $pool;
+
+    protected function setUp(): void
+    {
+        $factory = new ConnectionFactory();
+        $connection = $factory->sqlite(':memory:');
+
+        $this->pool = new ConnectionPool(writer: $connection, readers: []);
+
+        $connection->pdo()->exec('
+            CREATE TABLE ' . self::TABLE . ' (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                balance INTEGER NOT NULL
+            )
+        ');
+    }
+
+    public function testConditionalUpdateCollisionScenario(): void
+    {
+        $repositoryA = new Repository($this->pool);
+        $repositoryB = new Repository($this->pool);
+
+        $id = $repositoryA->insert(self::TABLE, self::PK, ['balance' => 100]);
+
+        // Both "clients" read the same starting balance (100).
+        $readByA = $repositoryA->findById(self::TABLE, self::PK, $id);
+        $readByB = $repositoryB->findById(self::TABLE, self::PK, $id);
+        $this->assertSame(100, $readByA['balance']);
+        $this->assertSame(100, $readByB['balance']);
+
+        // A writes first, expecting the balance it read.
+        $resultA = $repositoryA->update(self::TABLE, self::PK, $id, ['balance' => 150], ['balance' => 100]);
+        $this->assertTrue($resultA);
+
+        // B writes with the now-stale expectation and loses.
+        $resultB = $repositoryB->update(self::TABLE, self::PK, $id, ['balance' => 200], ['balance' => 100]);
+        $this->assertFalse($resultB);
+
+        $row = $repositoryA->findById(self::TABLE, self::PK, $id);
+        $this->assertSame(150, $row['balance']);
+    }
+}


### PR DESCRIPTION
Automatisierter Update-Release. Zielversion: v1.1.0

Additive API: optionaler $expected-Parameter (column => scalar|null) fuer optimistic-concurrency writes. Leeres $expected = byte-identisches SQL. Vertragsgrenzen: scalar|null-Guard, leeres $values mit gesetztem $expected wirft InvalidArgumentException. Tests: 95/157 inkl. Kollisionsszenario gegen MySQL, Postgres und SQLite (Adapter-Pfad).

https://claude.ai/code/session_01B3myqC1R5NcWWMHxDh6zBH